### PR TITLE
Add retries to http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Thin wrapper for `net/http`. [Docs on godoc.org](https://godoc.org/github.com/craigfurman/herottp).
 
 ## Features
+1. Allow for request retries.
 1. Disable following of redirects.
 1. Disable validation of certificates over HTTPS. **This is very dangerous and should
    only ever be done for testing!** Even then, it should only be a last resort.
@@ -11,6 +12,7 @@ Thin wrapper for `net/http`. [Docs on godoc.org](https://godoc.org/github.com/cr
 Example:
 ```
 client := herottp.New(herottp.Config{
+    MaxRetries: 2,
     NoFollowRedirect: true,
     DisableTLSCertificateVerification: false,
 })


### PR DESCRIPTION
- Useful for operations that fail due to timeout errors

related to pr here:
https://github.com/pivotal-cf/on-demand-service-broker/pull/8